### PR TITLE
Fix x64 MessageBox uType and stack reservation

### DIFF
--- a/0x0001-hello_world-x64/main.asm
+++ b/0x0001-hello_world-x64/main.asm
@@ -7,15 +7,15 @@ extrn PostQuitMessage: proc
 
 .code
 	main proc
-		sub	rsp, 20h			;shadow stack
+		sub	rsp, 28h			;shadow stack
 
-		mov	r9, rax				;UINT uType
+		xor	r9d, r9d				;UINT uType
 		lea	r8, msg_caption			;LPCSTR	lpCaption
 		lea	rdx, msg_txt			;LPCSTR	lpText
 		xor	rcx, rcx			;HWND hWnd
 		call MessageBoxA			;https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messageboxa
 		
-		add rsp, 20h				;restore shadow stack
+		add rsp, 28h				;restore shadow stack
 
 		xor	rcx, rcx			;int nExitCode
 		call PostQuitMessage			;https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postquitmessage


### PR DESCRIPTION
This updates the x64 hello world example to initialize the MessageBoxA uType argument explicitly and reserve 28h bytes before the call.

Changes:
- Use `xor r9d, r9d` so `uType` is explicitly `MB_OK`.
- Use `sub rsp, 28h` / `add rsp, 28h` to reserve shadow space plus alignment padding before calling MessageBoxA.